### PR TITLE
add button trigger channel

### DIFF
--- a/ESH-INF/thing/thing-types.xml
+++ b/ESH-INF/thing/thing-types.xml
@@ -27,6 +27,7 @@
         <description>The thing(-type) representing a Flic Button</description>
         <channels>
             <channel id="flicbutton-pressed-channel" typeId="flicbutton-pressed-channeltype"/>
+            <channel id="button-trigger" typeId="system.button"/>
         </channels>
     </thing-type>
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,23 @@ I strongly advice against using this within a production system right now. Curre
 	        Light_Bedroom.sendCommand(OFF)
 	end
 	```
-
+1. Or use rules to react to `SINGLE_PRESSED`, `DOUBLE_PRESSED` or `LONG_PRESSED` events:
+    ```
+    rule "My Flic Short Pressed Rule"
+    when
+        Channel "flicbutton:flicbutton-thing:1:80-e4-da-71-12-34:button-trigger" triggered SHORT_PRESSED
+    then
+        logInfo("Flic", "Flic 'short pressed' triggered")
+    end
+    
+    rule "My Flic Rule"
+    when
+        Channel "flicbutton:flicbutton-thing:1:80-e4-da-71-12-34:button-trigger" triggered
+    then
+        logInfo("Flic", "Flic pressed: " + receivedEvent.event)
+    end
+    ```
+     
 ## License
 
 The code within this repository is released under Eclipse Publice License 1.0. Nevertheless, the released .jar contains the (compiled) java clientlib for flicd by Shortcut Labs (which was excluded from this repositories source files). For this java clientlib, Shortcut Labs made 2 statements regarding licensing [here](https://github.com/50ButtonsEach/fliclib-linux-hci/issues/35):

--- a/src/main/java/org/openhab/binding/flicbutton/FlicButtonBindingConstants.java
+++ b/src/main/java/org/openhab/binding/flicbutton/FlicButtonBindingConstants.java
@@ -35,5 +35,6 @@ public class FlicButtonBindingConstants {
 
     // List of all Channel ids
     public final static String CHANNEL_ID_BUTTON_PRESSED = "flicbutton-pressed-channel";
+    public final static String CHANNEL_ID_BUTTON_TRIGGER = "button-trigger";
 
 }

--- a/src/main/java/org/openhab/binding/flicbutton/handler/FlicButtonHandler.java
+++ b/src/main/java/org/openhab/binding/flicbutton/handler/FlicButtonHandler.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.CommonTriggerEvents;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusDetail;
@@ -66,5 +67,22 @@ public class FlicButtonHandler extends BaseThingHandler {
     void flicButtonUp() {
         ChannelUID channelUID = thing.getChannel(FlicButtonBindingConstants.CHANNEL_ID_BUTTON_PRESSED).getUID();
         updateState(channelUID, OnOffType.OFF);
+    }
+
+    void flicButtonClickedSingle() {
+        flickButtonClicked(CommonTriggerEvents.SHORT_PRESSED);
+    }
+
+    void flicButtonClickedDouble() {
+        flickButtonClicked(CommonTriggerEvents.DOUBLE_PRESSED);
+    }
+
+    void flicButtonClickedHold() {
+        flickButtonClicked(CommonTriggerEvents.LONG_PRESSED);
+    }
+
+    private void flickButtonClicked(String event) {
+        ChannelUID channelUID = thing.getChannel(FlicButtonBindingConstants.CHANNEL_ID_BUTTON_TRIGGER).getUID();
+        triggerChannel(channelUID, event);
     }
 }

--- a/src/main/java/org/openhab/binding/flicbutton/handler/FlicDaemonBridgeEventListener.java
+++ b/src/main/java/org/openhab/binding/flicbutton/handler/FlicDaemonBridgeEventListener.java
@@ -73,4 +73,25 @@ public class FlicDaemonBridgeEventListener extends ButtonConnectionChannel.Callb
             }
         }
     }
+
+    @Override
+    public void onButtonSingleOrDoubleClickOrHold(ButtonConnectionChannel channel, ClickType clickType,
+            boolean wasQueued, int timeDiff) throws IOException {
+
+        logger.debug(channel.getBdaddr() + " " + clickType.name());
+
+        Thing flicButtonThing = bridgeHandler.getFlicButtonThing(channel.getBdaddr());
+
+        if (flicButtonThing != null) {
+            FlicButtonHandler thingHandler = (FlicButtonHandler) flicButtonThing.getHandler();
+
+            if (clickType == ClickType.ButtonSingleClick) {
+                thingHandler.flicButtonClickedSingle();
+            } else if (clickType == ClickType.ButtonDoubleClick) {
+                thingHandler.flicButtonClickedDouble();
+            } else if (clickType == ClickType.ButtonHold) {
+                thingHandler.flicButtonClickedHold();
+            }
+        }
+    }
 }


### PR DESCRIPTION
This adds a `button-trigger` channel to react to single, double or long presses. 
It is using the rather new trigger channels and therefore requires a recent Snapshot release.

Example rules are included in the README.
