### PR TITLE
fix bundle installation exception

### DIFF
--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -6,8 +6,10 @@ Bundle-Vendor: openHAB
 Bundle-Version: 0.5.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: ., lib/fliclib-linux-hci-client-4ddb2ac.jar
-Import-Package: 
+Import-Package: com.google.common.collect,
+ com.google.common.util.concurrent,
  org.eclipse.smarthome.config.core,
+ org.eclipse.smarthome.config.discovery,
  org.eclipse.smarthome.core.common,
  org.eclipse.smarthome.core.library.types,
  org.eclipse.smarthome.core.thing,
@@ -17,10 +19,8 @@ Import-Package:
  org.eclipse.smarthome.core.types,
  org.openhab.binding.flicbutton,
  org.openhab.binding.flicbutton.handler,
+ org.osgi.framework,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
 Export-Package: org.openhab.binding.flicbutton,
  org.openhab.binding.flicbutton.handler
-Require-Bundle: org.eclipse.smarthome.config.discovery,
- org.eclipse.osgi,
- com.google.guava

--- a/pom.xml
+++ b/pom.xml
@@ -15,15 +15,4 @@
 
   <name>FlicButton Binding</name>
   <packaging>eclipse-plugin</packaging>
-  
-  
-  <dependencies>
-        <dependency>
-            <groupId>com.shortcutlabs.flic</groupId>
-            <artifactId>fliclib-linux-hci-client</artifactId>
-            <version>master-4ddb2ac</version>     
-            <scope>system</scope>
-            <systemPath>${basedir}/lib/fliclib-linux-hci-client-4ddb2ac.jar</systemPath>
-        </dependency>
-   </dependencies>
 </project>


### PR DESCRIPTION
When I was trying to upgrade to latest version of flic button binding, I've received the following Exeption:
```
2016-11-13 11:04:27.444 [ERROR] [apache.karaf.shell.support.ShellUtil] - Exception caught while executing command
org.apache.karaf.shell.support.MultiException: Error executing command on bundles:
        Error starting bundle224: Could not resolve module: org.openhab.binding.flicbutton [224]
  Bundle was not resolved because of a uses contraint violation.
  org.osgi.service.resolver.ResolutionException: Uses constraint violation. Unable to resolve resource org.openhab.binding.flicbutton [osgi.identity; osgi.identity="org.openhab.binding.flicbutton"; type="
osgi.bundle"; version:Version="0.5.0.201611131003"; singleton:="true"] because it is exposed to package 'javax.annotation' from resources org.eclipse.osgi [osgi.identity; osgi.identity="org.eclipse.osgi";
 type="osgi.bundle"; version:Version="3.10.2.v20150203-1939"; singleton:="true"] and javax.annotation-api [osgi.identity; osgi.identity="javax.annotation-api"; type="osgi.bundle"; version:Version="1.2.0"]
 via two dependency chains.

Chain 1:
  org.openhab.binding.flicbutton [osgi.identity; osgi.identity="org.openhab.binding.flicbutton"; type="osgi.bundle"; version:Version="0.5.0.201611131003"; singleton:="true"]
    require: (osgi.wiring.bundle=org.eclipse.osgi)
     |
    provide: osgi.wiring.bundle: [org.eclipse.osgi, system.bundle]
  org.eclipse.osgi [osgi.identity; osgi.identity="org.eclipse.osgi"; type="osgi.bundle"; version:Version="3.10.2.v20150203-1939"; singleton:="true"]

Chain 2:
  org.openhab.binding.flicbutton [osgi.identity; osgi.identity="org.openhab.binding.flicbutton"; type="osgi.bundle"; version:Version="0.5.0.201611131003"; singleton:="true"]
    require: (osgi.wiring.bundle=com.google.guava)
     |
    provide: osgi.wiring.bundle; bundle-version:Version="18.0.0"; osgi.wiring.bundle="com.google.guava"
  com.google.guava [osgi.identity; osgi.identity="com.google.guava"; type="osgi.bundle"; version:Version="18.0.0"]
    import: (osgi.wiring.package=javax.annotation)
     |
    export: osgi.wiring.package: javax.annotation
  javax.annotation-api [osgi.identity; osgi.identity="javax.annotation-api"; type="osgi.bundle"; version:Version="1.2.0"]
        at org.apache.karaf.shell.support.MultiException.throwIf(MultiException.java:61)
        at org.apache.karaf.bundle.command.BundlesCommand.doExecute(BundlesCommand.java:69)[41:org.apache.karaf.bundle.core:4.0.4]
        at org.apache.karaf.bundle.command.BundlesCommand.execute(BundlesCommand.java:54)[41:org.apache.karaf.bundle.core:4.0.4]
        at org.apache.karaf.shell.impl.action.command.ActionCommand.execute(ActionCommand.java:83)[58:org.apache.karaf.shell.core:4.0.4]
        at org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand.execute(SecuredCommand.java:67)[58:org.apache.karaf.shell.core:4.0.4]
        at org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand.execute(SecuredCommand.java:87)[58:org.apache.karaf.shell.core:4.0.4]
        at org.apache.felix.gogo.runtime.Closure.executeCmd(Closure.java:480)[58:org.apache.karaf.shell.core:4.0.4]
        at org.apache.felix.gogo.runtime.Closure.executeStatement(Closure.java:406)[58:org.apache.karaf.shell.core:4.0.4]
        at org.apache.felix.gogo.runtime.Pipe.run(Pipe.java:108)[58:org.apache.karaf.shell.core:4.0.4]
        at org.apache.felix.gogo.runtime.Closure.execute(Closure.java:182)[58:org.apache.karaf.shell.core:4.0.4]
        at org.apache.felix.gogo.runtime.Closure.execute(Closure.java:119)[58:org.apache.karaf.shell.core:4.0.4]
        at org.apache.felix.gogo.runtime.CommandSessionImpl.execute(CommandSessionImpl.java:94)[58:org.apache.karaf.shell.core:4.0.4]
        at org.apache.karaf.shell.impl.console.ConsoleSessionImpl.run(ConsoleSessionImpl.java:270)[58:org.apache.karaf.shell.core:4.0.4]
        at java.lang.Thread.run(Thread.java:745)[:1.8.0_111]
```

Getting rid of `Required-Bundle` solved the problem.
Also removed the dependency from `pom.xml`, because it is not required, as far as I know.